### PR TITLE
cargo test failing fix

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -44,13 +44,18 @@ fn eval_list(
     till: &str,
 ) -> Result<serde_json::Value, Error> {
     let mut lst = vec![];
-
+    /*to keep track whether an entry is added to the list; */
+    let mut added = false;
     for (idx, section) in sections.iter().enumerate() {
         if section.reference == till {
             break;
         }
         if idx < start {
             continue;
+        }
+        /* after an entry being added to the list and the very next reference doesnt follow the same path=> meaning context is changed,break;next entries will not belong to the current list*/
+        if added &&  !section.reference.starts_with(path){
+            break;
         }
         if section.reference != path {
             continue;
@@ -61,6 +66,8 @@ fn eval_list(
             path.to_string() + "/"
         };
         lst.push(digest(&section.body, sections, idx, prefix, till)?);
+        added = true;
+
     }
 
     Ok(serde_json::Value::Array(lst))


### PR DESCRIPTION
after an entry being added to the list and the very next reference doesnt follow the same path=> meaning context is changed,break;next entries will not belong to the current list